### PR TITLE
Update navbar links to target home sections

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,34 +1,11 @@
 <script setup>
-import { RouterLink, RouterView, useRoute } from 'vue-router'
-
-const route = useRoute()
-
-const navigationLinks = [
-  { to: '/', label: 'خانه' },
-  { to: '/blog', label: 'بلاگ' }
-]
+import { RouterView } from 'vue-router'
+import MainNavbar from './components/MainNavbar.vue'
 </script>
 
 <template>
   <div class="flex min-h-screen flex-col bg-base-200 text-base-content">
-    <nav class="navbar bg-base-100 shadow">
-      <div class="container mx-auto flex flex-wrap items-center justify-between gap-4">
-        <RouterLink to="/" class="btn btn-ghost text-xl font-bold normal-case">
-          داریوش
-        </RouterLink>
-        <div class="flex flex-wrap gap-2">
-          <RouterLink
-            v-for="link in navigationLinks"
-            :key="link.to"
-            :to="link.to"
-            class="btn btn-ghost btn-sm"
-            :class="{ 'btn-active': route.path === link.to }"
-          >
-            {{ link.label }}
-          </RouterLink>
-        </div>
-      </div>
-    </nav>
+    <MainNavbar />
     <main class="flex-1">
       <RouterView />
     </main>

--- a/src/components/MainNavbar.vue
+++ b/src/components/MainNavbar.vue
@@ -1,0 +1,109 @@
+<script setup>
+import { ref } from 'vue'
+import { RouterLink, useRoute } from 'vue-router'
+
+const navigationLinks = [
+  { hash: '', label: 'صفحه اصلی' },
+  { hash: 'services', label: 'خدمات ما' },
+  { hash: 'products', label: 'محصولات ما' },
+  { hash: 'about', label: 'درباره ما' },
+  { hash: 'contact', label: 'تماس با ما' }
+]
+
+const route = useRoute()
+const isMenuOpen = ref(false)
+
+const toggleMenu = () => {
+  isMenuOpen.value = !isMenuOpen.value
+}
+
+const closeMenu = () => {
+  isMenuOpen.value = false
+}
+
+const buildLinkTarget = (hash) => ({
+  name: 'home',
+  ...(hash ? { hash: `#${hash}` } : {})
+})
+
+const isActive = (hash) => {
+  if (hash) {
+    return route.name === 'home' && route.hash === `#${hash}`
+  }
+
+  return route.name === 'home' && !route.hash
+}
+</script>
+
+<template>
+  <header class="bg-base-100 shadow">
+    <div class="container mx-auto px-4">
+      <div class="flex items-center justify-between py-4">
+        <div class="flex items-center gap-2">
+          <button
+            class="btn btn-ghost lg:hidden"
+            type="button"
+            @click="toggleMenu"
+            aria-label="باز کردن منو"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="1.5"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+            </svg>
+          </button>
+          <RouterLink to="/" class="btn btn-ghost text-xl font-bold normal-case">
+            داریوش
+          </RouterLink>
+        </div>
+      </div>
+
+      <nav class="hidden justify-center pb-4 lg:flex">
+        <ul class="menu menu-horizontal rounded-box bg-base-200/60 px-2">
+          <li v-for="link in navigationLinks" :key="link.label">
+            <RouterLink
+              :to="buildLinkTarget(link.hash)"
+              class="px-4"
+              :class="{ active: isActive(link.hash) }"
+            >
+              {{ link.label }}
+            </RouterLink>
+          </li>
+        </ul>
+      </nav>
+
+      <transition name="fade">
+        <nav v-if="isMenuOpen" class="pb-4 lg:hidden">
+          <ul class="menu rounded-box bg-base-200/60 p-2">
+            <li v-for="link in navigationLinks" :key="link.label">
+              <RouterLink
+                :to="buildLinkTarget(link.hash)"
+                :class="{ active: isActive(link.hash) }"
+                @click="closeMenu"
+              >
+                {{ link.label }}
+              </RouterLink>
+            </li>
+          </ul>
+        </nav>
+      </transition>
+    </div>
+  </header>
+</template>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease-in-out;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>


### PR DESCRIPTION
## Summary
- update the navbar link definitions to point to in-page anchors on the home view instead of separate routes
- generate active states and navigation targets based on hashes so the menu stays in sync with the current section

## Testing
- npm run build *(fails: missing optional dependency `@tailwindcss/vite` referenced by the existing Vite config)*

------
https://chatgpt.com/codex/tasks/task_e_68dfbdbbabb0833095bd70c302c7929d